### PR TITLE
Update to atomic CLI from rpm-ostree and fix deprecated calls

### DIFF
--- a/atomictests.py
+++ b/atomictests.py
@@ -62,7 +62,7 @@ class TestAtomicUpgradeRun(unittest.TestCase):
         # This file should persist, even after rolling back the upgrade.
         # This we assert in
         # TestAtomicRollbackPostReboot.test_atomic_rollback_post_reboot
-        with open('/etc/file1', '') as f:
+        with open('/etc/file1', 'w') as f:
             f.write('1')
             f.close
 
@@ -93,7 +93,7 @@ class TestAtomicRollbackRun(unittest.TestCase):
         # We make changes to the system by creating /etc/file2 before
         # running rollback. Once rollback is run, /etc/file2 will be
         # removed. We assert that in the following test case.
-        with open('/etc/file2', '') as f:
+        with open('/etc/file2', 'w') as f:
             f.write('2')
             f.close
 

--- a/atomictests.py
+++ b/atomictests.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import re
 import time
-from .testutils import system, if_atomic
+from .testutils import system, if_atomic, if_upgrade
 
 
 @unittest.skipUnless(if_atomic(), "It's not an atomic image")
@@ -54,7 +54,7 @@ class TestDockerInstalled(unittest.TestCase):
 
 
 @unittest.skipUnless(if_atomic(), "It's not an Atomic image")
-@unittest.skipUnless(if_upgradeble(), "No upgrade is available for this Atomic host")
+@unittest.skipUnless(if_upgrade(), "No upgrade is available for this Atomic host")
 class TestAtomicUpgradeRun(unittest.TestCase):
 
     def test_upgrade_run(self):
@@ -75,7 +75,7 @@ class TestAtomicUpgradeRun(unittest.TestCase):
 
 
 @unittest.skipUnless(if_atomic(), "It's not an Atomic image")
-@unittest.skipUnless(if_upgradeble(), "No upgrade is available for this Atomic host")
+@unittest.skipUnless(if_upgrade(), "No upgrade is available for this Atomic host")
 class TestAtomicUpgradePostReboot(unittest.TestCase):
 
     def test_upgrade_post_reboot(self):
@@ -86,7 +86,7 @@ class TestAtomicUpgradePostReboot(unittest.TestCase):
 
 
 @unittest.skipUnless(if_atomic(), "It's not an Atomic image")
-@unittest.skipUnless(if_upgradeble(), "No upgrade is available for this Atomic host")
+@unittest.skipUnless(if_upgrade(), "No upgrade is available for this Atomic host")
 class TestAtomicRollbackRun(unittest.TestCase):
 
     def test_atomic_rollback_run(self):
@@ -96,7 +96,7 @@ class TestAtomicRollbackRun(unittest.TestCase):
         with open('/etc/file2', '') as f:
             f.write('2')
             f.close
-            
+
         out, err, eid = system('sudo atomic host rollback')
         err = err.decode('utf-8')
         self.assertFalse(err)
@@ -105,7 +105,7 @@ class TestAtomicRollbackRun(unittest.TestCase):
 
 
 @unittest.skipUnless(if_atomic(), "It's not an Atomic image")
-@unittest.skipUnless(if_upgradeble(), "No upgrade is available for this Atomic host")
+@unittest.skipUnless(if_upgrade(), "No upgrade is available for this Atomic host")
 class TestAtomicRollbackPostReboot(unittest.TestCase):
 
     def test_atomic_rollback_post_reboot(self):

--- a/atomictests.py
+++ b/atomictests.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import re
 import time
-from .testutils import system, if_atomic, if_upgrade
+from .testutils import system, if_atomic, if_upgrade, if_rollback
 
 
 @unittest.skipUnless(if_atomic(), "It's not an atomic image")

--- a/atomictests.py
+++ b/atomictests.py
@@ -1,4 +1,4 @@
-mport unittest
+import unittest
 import os
 import re
 import time

--- a/atomictests.py
+++ b/atomictests.py
@@ -75,7 +75,7 @@ class TestAtomicUpgradeRun(unittest.TestCase):
 
 
 @unittest.skipUnless(if_atomic(), "It's not an Atomic image")
-@unittest.skipUnless(if_upgrade(), "No upgrade is available for this Atomic host")
+@unittest.skipUnless(if_rollback(), "No rollback is available for this Atomic host")
 class TestAtomicUpgradePostReboot(unittest.TestCase):
 
     def test_upgrade_post_reboot(self):
@@ -114,10 +114,10 @@ class TestAtomicRollbackPostReboot(unittest.TestCase):
         self.assertTrue(out)
 
         # Assert that file1 is present
-        self.assertTrue(path.isfile('/etc/file1'))
+        self.assertTrue(os.path.isfile('/etc/file1'))
 
         # Assert that file2 is not present
-        self.assertFalse(path.isfile('/etc/file2'))
+        self.assertFalse(os.path.isfile('/etc/file2'))
 
         # Assert that running busybox docker image works after rollback
         out, err, eid = system(

--- a/atomictests.py
+++ b/atomictests.py
@@ -86,7 +86,7 @@ class TestAtomicUpgradePostReboot(unittest.TestCase):
 
 
 @unittest.skipUnless(if_atomic(), "It's not an Atomic image")
-@unittest.skipUnless(if_upgrade(), "No upgrade is available for this Atomic host")
+@unittest.skipUnless(if_rollback(), "No rollback is available for this Atomic host")
 class TestAtomicRollbackRun(unittest.TestCase):
 
     def test_atomic_rollback_run(self):
@@ -105,7 +105,7 @@ class TestAtomicRollbackRun(unittest.TestCase):
 
 
 @unittest.skipUnless(if_atomic(), "It's not an Atomic image")
-@unittest.skipUnless(if_upgrade(), "No upgrade is available for this Atomic host")
+@unittest.skipUnless(if_rollback(), "No rollback is available for this Atomic host")
 class TestAtomicRollbackPostReboot(unittest.TestCase):
 
     def test_atomic_rollback_post_reboot(self):

--- a/atomictests.py
+++ b/atomictests.py
@@ -63,7 +63,7 @@ class TestAtomicUpgradeRun(unittest.TestCase):
         # This we assert in
         # TestAtomicRollbackPostReboot.test_atomic_rollback_post_reboot
         with open('/etc/file1', 'w') as f:
-            f.write('1')
+            f.write('1\n')
             f.close
 
         out, err, eid = system('sudo atomic host upgrade')
@@ -94,7 +94,7 @@ class TestAtomicRollbackRun(unittest.TestCase):
         # running rollback. Once rollback is run, /etc/file2 will be
         # removed. We assert that in the following test case.
         with open('/etc/file2', 'w') as f:
-            f.write('2')
+            f.write('2\n')
             f.close
 
         out, err, eid = system('sudo atomic host rollback')

--- a/atomictests.py
+++ b/atomictests.py
@@ -1,4 +1,4 @@
-import unittest
+mport unittest
 import os
 import re
 import time
@@ -12,7 +12,7 @@ class TestAtomicFirstBootRun(unittest.TestCase):
         out, err, eid = system(
             'docker run --rm busybox true && echo "PASS"')
         out = out.decode('utf-8')
-        self.assertEquals('PASS\n', out)
+        self.assertEqual('PASS\n', out)
 
 
 @unittest.skipUnless(if_atomic(), "It's not an Atomic image")
@@ -57,7 +57,7 @@ class TestDockerInstalled(unittest.TestCase):
 class TestAtomicUpgradeRun(unittest.TestCase):
 
     def test_upgrade_run(self):
-        out, err, eid = system('sudo rpm-ostree status')
+        out, err, eid = system('sudo atomic host status')
         out = out.decode('utf-8')
         self.assertTrue(out)
         out, err, eid = system('sudo ostree admin status')
@@ -74,7 +74,7 @@ class TestAtomicUpgradeRun(unittest.TestCase):
         err = err.decode('utf-8')
         print(out, err)
         self.assertFalse(err)
-        out, err, eid = system('sudo rpm-ostree upgrade')
+        out, err, eid = system('sudo atomic host upgrade')
         err = err.decode('utf-8')
         # Assert successful run
         print(out, err)
@@ -89,7 +89,7 @@ class TestAtomicUpgradePostReboot(unittest.TestCase):
         out, err, eid = system(
             'docker run --rm busybox true && echo "PASS"')
         out = out.decode('utf-8')
-        self.assertEquals('PASS\n', out)
+        self.assertEqual('PASS\n', out)
 
 
 @unittest.skipUnless(if_atomic(), "It's not an Atomic image")
@@ -105,7 +105,7 @@ class TestAtomicRollbackRun(unittest.TestCase):
         self.assertFalse(err)
         print(out, err)
 
-        out, err, eid = system('sudo rpm-ostree rollback')
+        out, err, eid = system('sudo atomic host rollback')
         err = err.decode('utf-8')
         self.assertFalse(err)
         print(out, err)
@@ -116,7 +116,7 @@ class TestAtomicRollbackRun(unittest.TestCase):
 class TestAtomicRollbackPostReboot(unittest.TestCase):
 
     def test_atomic_rollback_post_reboot(self):
-        out, err, eid = system('rpm-ostree status')
+        out, err, eid = system('atomic host status')
         out = out.decode('utf-8')
         self.assertTrue(out)
 

--- a/cloudtests.py
+++ b/cloudtests.py
@@ -10,7 +10,7 @@ class TestBase(unittest.TestCase):
         out, err, eid = system('sudo getenforce')
         out = out.strip()
         out = out.decode('utf-8')
-        self.assertEquals(out, 'Enforcing')
+        self.assertEqual(out, 'Enforcing')
 
     def test_logging(self):
         "Tests journald logging"

--- a/testutils.py
+++ b/testutils.py
@@ -18,3 +18,11 @@ def if_atomic():
     if eid != 0:
         return False
     return True
+
+
+def if_upgradeble():
+    "Check for available ostree upgrade for host."
+    out, err, eid = system('sudo atomic host upgrade --check')
+    if eid != 0:
+        return False
+    return True

--- a/testutils.py
+++ b/testutils.py
@@ -19,10 +19,16 @@ def if_atomic():
         return False
     return True
 
-
 def if_upgrade():
     "Check for available ostree upgrade for host."
     out, err, eid = system('sudo atomic host upgrade --check')
     if eid != 0:
         return False
     return True
+
+def if_rollback():
+    "Check for available rollback target for host."
+    out, err, eid = system('sudo atomic host status -p')
+    if "ROLLBACK TARGET" in out:
+        return True
+    return False

--- a/testutils.py
+++ b/testutils.py
@@ -29,6 +29,7 @@ def if_upgrade():
 def if_rollback():
     "Check for available rollback target for host."
     out, err, eid = system('sudo atomic host status -p')
+    out = out.decode('utf-8')
     if "ROLLBACK TARGET" in out:
         return True
     return False

--- a/testutils.py
+++ b/testutils.py
@@ -20,7 +20,7 @@ def if_atomic():
     return True
 
 
-def if_upgradeble():
+def if_upgrade():
     "Check for available ostree upgrade for host."
     out, err, eid = system('sudo atomic host upgrade --check')
     if eid != 0:


### PR DESCRIPTION
To better cover the atomic CLI tool, I moved some rpm-ostree based tests to atomic based tests where it made sense. This will provide a base for further coverage of the atomic binary.

I also ran into some deprecation warnings and went ahead and updated those assertEquals to assertEqual where found.
