### PR TITLE
Detect traditional network naming, test for eth0 if found.

### DIFF
--- a/cloudtests.py
+++ b/cloudtests.py
@@ -1,5 +1,5 @@
 import unittest
-from .testutils import system, if_atomic
+from .testutils import system, if_atomic, if_netname_traditional
 
 
 class TestBase(unittest.TestCase):
@@ -10,7 +10,7 @@ class TestBase(unittest.TestCase):
         out, err, eid = system('sudo getenforce')
         out = out.strip()
         out = out.decode('utf-8')
-        self.assertEquals(out, 'Enforcing')
+        self.assertEqual(out, 'Enforcing')
 
     def test_logging(self):
         "Tests journald logging"
@@ -49,8 +49,13 @@ class Testtmpmount(unittest.TestCase):
         out = out.decode('utf-8')
         self.assertEqual(out.strip(), '1777')
 
-
-
+# https://github.com/kushaldas/tunirtests/issues/29
+@unittest.skipIf(not if_netname_traditional(), "Image is using predictable naming convention.")
+class Testnetname(unittest.TestCase):
+    "If traditional net naming is turned on, we should see eth0 structures here"
+    def test_net_name(self):
+        out, err, eid = system("stat /sys/class/net/eth0/operstate")
+        self.assertEqual(eid, 0, err)
 
 
 if __name__ == '__main__':

--- a/testutils.py
+++ b/testutils.py
@@ -18,3 +18,12 @@ def if_atomic():
     if eid != 0:
         return False
     return True
+
+def if_netname_traditional():
+    "Identify classic network interface naming convention"
+    out, err, eid = system('cat /proc/cmdline')
+    out = out.decode('utf-8')
+    print(repr(out))
+    if "net.ifnames=0" in out:
+        return True
+    return False


### PR DESCRIPTION
Closes #29 

Added a condition to test for "net.ifnames" in boot command line to determine if the system being tested is using traditional (eth0 .. ethN) naming or predictable (device specific eno1, wlp3s0) naming for network devices.

Added test for those systems using traditional naming (eth0 .. ethN) using the /sys/class/net section of the sysfs device tree.  The file being detected should exist if eth0 device is in place.

One note: the condition in testutils.py currently emits the boot command line, primarily as a debugging aid.  This should probably be removed but I wanted to make sure that for acceptance it was still available.
