### PR TITLE
Change test for identifying an Atomic host

### DIFF
--- a/testutils.py
+++ b/testutils.py
@@ -14,7 +14,7 @@ def system(cmd):
 
 def if_atomic():
     "Tries to identify atomic image."
-    out, err, eid = system('which rpm-ostree')
+    out, err, eid = system('stat /run/ostree-booted')
     if eid != 0:
         return False
     return True


### PR DESCRIPTION
Testing for the existence of the `rpm-ostree` binary isn't a good test for an Atomic host as that utility is also used to create rpm-ostree repos on non-Atomic hosts.

Atomic hosts will have an identifier in`/run` that signals this is an OStree host.  Until the Atomic host gets a variant ID in `os-release` this is probably the most reliable test for "atomic-ness".
